### PR TITLE
Fixing typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ OBS: Do in this order!
 
 install keyring package:
 
-`wget wget https://github.com/endeavouros-team/repository/releases/download/repository/endeavouros-keyring-1-1-any.pkg.tar.xz`
+ wget https://github.com/endeavouros-team/repository/releases/download/repository/endeavouros-keyring-1-1-any.pkg.tar.xz`
 
-`wget https://github.com/endeavouros-team/repository/releases/download/repository/endeavouros-mirrorlist-1-1-any.pkg.tar.xz`
+`wget https://github.com/endeavouros-team/repository/releases/download/repository/endeavouros-mirrorlist-1-2-any.pkg.tar.xz`
 
 `sudo pacman -U endeavouros-keyring-1-1-any.pkg.tar.xz`
 
-`sudo pacman -U endeavouros-mirrorlist-1-1-any.pkg.tar.xz`
+`sudo pacman -U endeavouros-mirrorlist-1-2-any.pkg.tar.xz`
 
 add the repo bellow to your /etc/pacman.conf
 
 `[endeavouros]`\
 `SigLevel = PackageRequired`\
-`Include = /etc/pacman.d/endeavouros-mirrorlist`\
+`Include = /etc/pacman.d/endeavouros-mirrorlist`
 
 
 `sudo pacman -Syy`


### PR DESCRIPTION
I was trying today to generate an ISO in order to test it. I noticed some typos.

1) You need only one wget in keyring line.
2) Mirrorlist package changed its name. So let's modify it!
3) There is no need of a backslash in repository entry.