### PR TITLE
Let's simplify pacman command line :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 These are the basic needed files and folders to build EndeavourOS system.
 
 # Install necessary packages first
-`sudo pacman -S archiso arch-install-scripts git squashfs-tools `
+`sudo pacman -S archiso arch-install-scripts git --needed`
 
 Clone:\
 `git clone https://github.com/endeavouros-team/archiso-offlineinstaller.git`


### PR DESCRIPTION
Some cleanup in first command line

1. adding --needed asking pacman to install only missing packages
2.  squashfs-tools is a _hard_ dependency of archiso.

https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/archiso

`depends=('make' 'arch-install-scripts' 'squashfs-tools' 'libisoburn' 'dosfstools' 'lynx')`

My $0.02 here :D