### PR TITLE
Fixing missing EndeavourOS icon in whisker Menu

### DIFF
--- a/airootfs/etc/skel/.config/xfce4/panel/whiskermenu-5.rc
+++ b/airootfs/etc/skel/.config/xfce4/panel/whiskermenu-5.rc
@@ -1,7 +1,7 @@
 favorites=firefox.desktop,xfce4-terminal.desktop,org.xfce.Parole.desktop,Thunar.desktop,xfce-settings-manager.desktop
 recent=
 button-title=EndeavourOS
-button-icon=/usr/share/endeavouros/EndeavourOS-E-icon.png
+button-icon=/usr/share/endeavouros/EndeavourOS-icon-E.png
 button-single-row=false
 show-button-title=true
 show-button-icon=true


### PR DESCRIPTION
It was not correctly defined.

/usr/share/endeavouros/EndeavourOS-E-icon.png instead of /usr/share/endeavouros/EndeavourOS-icon-E.png

Ouch!